### PR TITLE
Port Scrollable-Tooltips to Minecraft 1.19

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.18.2
-yarn_mappings=1.18.2+build.3
-loader_version=0.14.5
+minecraft_version=1.19
+yarn_mappings=1.19+build.4
+loader_version=0.14.8
 # Mod Properties
 mod_version=1.0.1+1.18.2
 maven_group=net.adon15
 archives_base_name=scrollable_tooltips
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.51.1+1.18.2
+fabric_version=0.56.1+1.19

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,6 +23,6 @@
 	"depends": {
 		"fabricloader": ">=0.14.5",
 		"fabric": "*",
-		"minecraft": "1.18.2"
+		"minecraft": "1.19"
 	}
 }


### PR DESCRIPTION
Hello,

I just "ported" your mod to 1.19. I literally just changed a few values in config files and it seems to work right away.

Edit: FYI, I haven't bumped the mod version in this PR